### PR TITLE
build open-vmdk

### DIFF
--- a/app-misc/open-vmdk/open-vmdk-1.0.ebuild
+++ b/app-misc/open-vmdk/open-vmdk-1.0.ebuild
@@ -1,0 +1,25 @@
+# Copyright 2014 VMware
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit git-2
+
+DESCRIPTION="Tool to convert vmdk to an ova file"
+HOMEPAGE="https://github.com/vmware/open-vmdk"
+LICENSE="LGPL-2"
+SLOT="0"
+
+EGIT_REPO_URI="https://github.com/vmware/open-vmdk"
+EGIT_BRANCH="master"
+
+KEYWORDS="amd64 ~x86"
+IUSE=""
+
+DEPEND=""
+RDEPEND="app-misc/jq ${DEPEND}"
+
+src_install() {
+	emake DESTDIR="${D}" install
+}


### PR DESCRIPTION
This adds open-vmdk. This is a set of tools to create a stream-optimized vmdk, and an ova file from that. I will create a related PR with changes to make use of these tools to create a CoreOS ova file, which can be imported into VMware ESXi and Fusion/Workstation.

I don't know where to add this as adependency to the SDK, so that it gets built and installed in the SDK by default. Help is appreciated.
