### PR TITLE
README: replace old ChromeOS README

### DIFF
--- a/PRESUBMIT.cfg
+++ b/PRESUBMIT.cfg
@@ -1,9 +1,0 @@
-# This sample config file disables all of the ChromiumOS source style checks.
-# Comment out the disable-flags for any checks you want to leave enabled.
-
-[Hook Overrides]
-stray_whitespace_check: false
-long_line_check: false
-cros_license_check: false
-tab_check: false
-

--- a/README
+++ b/README
@@ -1,6 +1,0 @@
-Copyright (c) 2011 The Chromium OS Authors. All rights reserved.
-Use of this source code is governed by a BSD-style license that can be
-found in the LICENSE file.
-
-This overlay contains Portage packages that are part of the Chromium OS build
-and are exact copies of upstream Portage packages.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+This overlay contains curated unmodified Gentoo packages that are part
+of the CoreOS build and are exact copies of upstream Gentoo packages.
+
+Use `src/scripts/update_ebuilds` to fetch the latest copy from Gentoo:
+
+    cd ~/trunk/src/scripts
+    repo start update-foo ../third-party/portage-stable
+    ./update_ebuilds --commit app-fun/foo
+
+Note: `update_ebuilds` can fetch from either Gentoo's anonymous CVS or
+Rsync services, both of which will ban users making excessive requests.
+If you have a lot of related packages to update or just aren't quite
+sure what you are getting into please pull down a local copy to work
+from:
+
+    rsync -rtlv rsync://rsync.gentoo.org/gentoo-portage ~/
+    ./update_ebuilds --commit --portage ~/gentoo-portage app-fun/foo
+
+Licensing information can be found in the respective files, so consult
+them directly. Most ebuilds are licensed under the GPL version 2.
+
+Upstream Gentoo sources: http://sources.gentoo.org/gentoo-x86/


### PR DESCRIPTION
Now featuring correct licensing info and useful developer information!

Requested in https://groups.google.com/forum/#!topic/coreos-dev/goLG-5r8m1s