### PR TITLE
autotools.eclass: Update dependency for autoconf-2.13.

### DIFF
--- a/eclass/autotools.eclass
+++ b/eclass/autotools.eclass
@@ -82,7 +82,7 @@ fi
 if [[ -n ${WANT_AUTOCONF} ]] ; then
 	case ${WANT_AUTOCONF} in
 		none)       _autoconf_atom="" ;; # some packages don't require autoconf at all
-		2.1)        _autoconf_atom="=sys-devel/autoconf-${WANT_AUTOCONF}*" ;;
+		2.1)        _autoconf_atom="~sys-devel/autoconf-2.13" ;;
 		# if you change the "latest" version here, change also autotools_env_setup
 		latest|2.5) _autoconf_atom=">=sys-devel/autoconf-2.69" ;;
 		*)          die "Invalid WANT_AUTOCONF value '${WANT_AUTOCONF}'" ;;


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=560484